### PR TITLE
Restore PeopleCard link anchors

### DIFF
--- a/murst-app/src/App.jsx
+++ b/murst-app/src/App.jsx
@@ -550,12 +550,21 @@ const PeopleCard = ({ person }) => (
                     <p className="font-mono text-murst-green mb-4">{person.role}</p>
                     <p className="text-gray-400 mb-6 font-sans">{person.bio}</p>
                     <div className="flex items-center gap-6">
-                        {person.links.map(link => (
-                            <div key={link.name} className="group flex items-center gap-2 text-sm font-mono text-gray-400">
-                                {link.name === 'GitHub' ? <GitHubIcon /> : <LinkIcon />}
-                                {link.name}
-                            </div>
-                        ))}
+                        {person.links.map(link => {
+                            const isExternal = /^https?:\/\//.test(link.url);
+                            return (
+                                <a
+                                    key={link.name}
+                                    href={link.url}
+                                    className="group flex items-center gap-2 text-sm font-mono text-gray-400"
+                                    target={isExternal ? "_blank" : undefined}
+                                    rel={isExternal ? "noopener noreferrer" : undefined}
+                                >
+                                    {link.name === 'GitHub' ? <GitHubIcon /> : <LinkIcon />}
+                                    {link.name}
+                                </a>
+                            );
+                        })}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- wrap PeopleCard social links with anchor elements while preserving styling
- open external links in a new tab with appropriate security attributes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6908e9d580648332b6b8e7eb99d645fb