### PR TITLE
Adjust horizontal bar colors by type

### DIFF
--- a/murst-app/src/App.jsx
+++ b/murst-app/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { BarChart, Bar, AreaChart, Area, ScatterChart, Scatter, XAxis, YAxis, ZAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, LabelList } from 'recharts';
+import { BarChart, Bar, AreaChart, Area, ScatterChart, Scatter, XAxis, YAxis, ZAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, LabelList, Cell } from 'recharts';
 
 
 // --- DATA STORE ---
@@ -259,7 +259,7 @@ const HorizontalBarChartComponent = ({ data }) => (
             <Bar dataKey="score">
                 {
                     data.map((entry, index) => (
-                        <Bar key={`cell-${index}`} fill={entry.type === 'MoE' ? '#6AF2A2' : '#737373'} />
+                        <Cell key={`cell-${index}`} fill={entry.type === 'MoE' ? '#6AF2A2' : '#737373'} />
                     ))
                 }
                 <LabelList dataKey="score" position="right" style={{ fill: '#e5e7eb' }} />


### PR DESCRIPTION
## Summary
- import the Cell component from recharts
- render horizontal bar segments with Cell to color MoE entries green and Dense entries gray

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908e9d42340833293a050e4f46e7862